### PR TITLE
Adding token_count = "token" trimming in the result.

### DIFF
--- a/core/client/src/results.ts
+++ b/core/client/src/results.ts
@@ -97,10 +97,12 @@ class PolymathResults {
   }
 
   trim(count: number, countType: CountType = "bit"): void {
-    if (countType != "bit") {
-      throw new Error("Only bits are supported at this time");
+    if (countType == "bit") {
+      this._bits = this._bits.slice(0, count);
     }
-    this._bits = this._bits.slice(0, count);
+    else if (countType == "token") {
+      this._bits = this.maxBits(count);
+    }
   }
 
   sortBitsBySimilarity(): void {


### PR DESCRIPTION
This should help bring the JS endpoints inline with the validator.

Limits the total number of bits returned to that specified by token_count