### PR TITLE
Fix `core/cli/README.md` errors

### DIFF
--- a/core/cli/README.md
+++ b/core/cli/README.md
@@ -81,12 +81,12 @@ polymath -c local-knowledge complete --completion-stream true --completion-model
 
 This example turns on streaming, and sets the completion model to the new default turbo mode.
 
-### Import content ✅
+### Ingest content ✅
 
 e.g:
 
 ```shell
-polymath import rss https://pau.kinlan.me/index.xml --destination=./libraries/medium-2023.json
+polymath ingest rss https://pau.kinlan.me/index.xml --destination=./libraries/medium-2023.json
 ```
 
 #### Using a self hosted importer ✅

--- a/core/cli/README.md
+++ b/core/cli/README.md
@@ -86,7 +86,7 @@ This example turns on streaming, and sets the completion model to the new defaul
 e.g:
 
 ```shell
-polymath ingest rss https://pau.kinlan.me/index.xml --destination=./libraries/medium-2023.json
+polymath ingest rss https://pau.kinlan.me/index.xml --destination=./libraries
 ```
 
 #### Using a self hosted importer ✅

--- a/core/cli/README.md
+++ b/core/cli/README.md
@@ -86,7 +86,7 @@ This example turns on streaming, and sets the completion model to the new defaul
 e.g:
 
 ```shell
-polymath ingest rss https://pau.kinlan.me/index.xml --destination=./libraries
+polymath ingest rss https://paul.kinlan.me/index.xml --destination=./libraries
 ```
 
 #### Using a self hosted importer ✅


### PR DESCRIPTION
Thanks for this tool.  It's really exciting to play with!

This PR fixes 3 issues I bumped into when trying to run the ingest example in the `core/cli/README.md` file:
1. Update the command from `import` to `ingest`
2. Add a missing `l` in the `paul.kinlan.me` RSS URL
3. Update `--destination` argument to be a folder, not a full path to the file

